### PR TITLE
removes HTTPS middleware and port from docker file

### DIFF
--- a/FSEJobFinder/FSEDataFeedAPI/Program.cs
+++ b/FSEJobFinder/FSEDataFeedAPI/Program.cs
@@ -75,7 +75,7 @@ else
     app.UseExceptionHandler("/error");
 }
 
-app.UseHttpsRedirection();
+//app.UseHttpsRedirection();
 
 app.UseCors();
 

--- a/FSEJobFinder/FSEDataFeedAPI/appsettings.json
+++ b/FSEJobFinder/FSEDataFeedAPI/appsettings.json
@@ -1,5 +1,4 @@
 {
-  "https_port": 443,
   "Logging": {
     "LogLevel": {
       "Default": "Information",


### PR DESCRIPTION
As we use a nginx reverse proxy that already has HTTPS enables, we do not need the app itself to use HTTPS. This change disables the HTTPS middleware and removes the exposed 443 port from the container.