### PR TITLE
removes debug code

### DIFF
--- a/FSEJobFinder/FSEDataFeedAPI/Program.cs
+++ b/FSEJobFinder/FSEDataFeedAPI/Program.cs
@@ -82,16 +82,6 @@ else
 }
 
 //app.UseHttpsRedirection();
-Console.WriteLine("getting conn string from env...");
-string connstr = Environment.GetEnvironmentVariable("FSEJOBFINDER_CONNECTIONSTRING");
-if (connstr == null || connstr.Length == 0)
-{
-    Console.WriteLine("conn str was null or empty");
-}
-else
-{
-    Console.WriteLine(connstr);
-}
 
 app.UseCors();
 


### PR DESCRIPTION
DB connection issue was caused by two things.

1. Security rule on MongoDb Atlas side. Web server ip missing from access list.
2. Jenkins build script could not see the env variable with the connection string. Resolved with Environment Injector plugin and setting script to run with sh in the build step.